### PR TITLE
typing: annotate functions in generation scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "asbuild:optimized": "asc assembly/index.ts --target release",
     "asbuild": "npm run asbuild:untouched && npm run asbuild:optimized",
     "asbuild:empty": "asc --config asconfig.empty.json",
-    "generate-tz": "node tzdb/index.mjs",
+    "generate-tz": "node tzdb/index.js",
     "tsrun": "ts-node ts/index.ts"
   },
   "author": "colin.eberhardt@gmail.com",

--- a/tzdb/emitter.js
+++ b/tzdb/emitter.js
@@ -1,22 +1,40 @@
-const emitZoneOffset = (offset) => {
+//@ts-check
+
+/**
+ * @param offset {import("./parser.js").Offset}
+ * @returns {string}
+ */
+function emitZoneOffset(offset) {
   return `
     // ${offset.line.replace("\t", "    ")}
-    new ZoneOffset(${offset.standardOffset * 1_000}, "${offset.rules}",
+    new ZoneOffset(${offset.standardOffset * 1000}, "${offset.rules}",
         "${offset.format}", ${offset.until ? offset.until.millis : -1})
   `;
-};
+}
 
-const emitZone = (zone) => {
+/**
+ * @param zone {import("./parser.js").Zone} 
+ * @returns {string}
+ */
+function emitZone(zone) {
   return `
     zones.set("${zone.name}",
       new Zone("${zone.name}", [${zone.ruleRefs.map(emitZoneOffset)}]));`;
-};
+}
 
-const emitZones = (zones) => {
-  return zones.map(emitZone).join("")
-};
+/**
+ * @param zones {import("./parser.js").Zone[]}
+ * @returns {string}
+ */
+function emitZones(zones) {
+  return zones.map(emitZone).join("");
+}
 
-const emitDay = (day) => {
+/**
+ * @param day {import("./parser.js").Day}
+ * @returns {string}
+ */
+function emitDay(day) {
   if (day.type == "day") {
     return `new DayOfMonth(${day.value})`;
   }
@@ -26,25 +44,37 @@ const emitDay = (day) => {
   if (day.type == "last-day") {
     return `new LastDay(${day.value})`;
   }
-};
+}
 
-const emitRule = (rule) => {
+/**
+ * @param rule {import("./parser.js").Rule}
+ * @returns {string}
+ */
+function emitRule(rule) {
   return `
   // ${rule.line.replace("\t", "    ")}
   new Rule("${rule.name}", ${rule.startYear}, ${rule.endYear},
     ${rule.inMonth}, ${emitDay(rule.day)}, ${rule.time.totalMinutes},
     ${rule.time.zone === "local" ? "AtTimeZone.Local" : "AtTimeZone.UTC"},
-    ${rule.offset * 1_000})
+    ${rule.offset * 1000})
 `;
-};
+}
 
-const emitRules = (rules) => {
+/**
+ * @param rules {import("./parser.js").Rule[]}
+ * @returns {string}
+ */
+function emitRules(rules) {
   return `
     const rules = [${rules.map(emitRule).join(",")}];
   `;
-};
+}
 
-const emit = (tzdb) => {
+/**
+ * @param {import("./parser.js").Database} tzdb
+ * @returns {string}
+ */
+export function emit(tzdb) {
   return `
   import { Rule, DayOfMonth, NextDayAfter, LastDay, AtTimeZone } from "./rule";
   import { Zone, ZoneOffset } from "./zone";
@@ -58,6 +88,5 @@ const emit = (tzdb) => {
     zones, rules
   };
 `;
-};
+}
 
-export { emit };

--- a/tzdb/index.js
+++ b/tzdb/index.js
@@ -1,13 +1,14 @@
+//@ts-check
 import fs from "fs";
-import { parserDatabase } from "./parser.mjs";
-import { emit } from "./emitter.mjs";
+import { parseDatabase } from "./parser.js";
+import { emit } from "./emitter.js";
 import prettier from "prettier";
 
 const databases = ["northamerica", "europe"];
 
 const db = databases
   .map((d) => fs.readFileSync(`tzdb/iana/${d}`, "UTF8"))
-  .map(parserDatabase)
+  .map(parseDatabase)
   .reduce(
     (prev, curr) => ({
       zones: prev.zones.concat(curr.zones),

--- a/tzdb/package.json
+++ b/tzdb/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}


### PR DESCRIPTION
1. converted arrow function to real function definitions
2. annotate and add `@typedefs` to enable typechecking using `//@ts-check`
3. rename files to `.js` because TS doesn't accepts `.mjs` => Required the use of `"type": "module"` in `package.json` to let node know to read files as modules.
4.  fix `parseEndYear` returning `-1` instead of a string
5. rename `parserDatabase` to `parseDatabase`

All of this because I want to be typesafe in future PRs